### PR TITLE
Checking key in addition to the 'key' property

### DIFF
--- a/lib/jira/resource/metadata.rb
+++ b/lib/jira/resource/metadata.rb
@@ -39,7 +39,7 @@ module JIRA
       end
 
       def unsupported_fields(type)
-        required_fields(type).reject { |key, v| (main_custom_fields.values+DEFAULT_REQUIRED_KEYS).include? v['key'] }
+        required_fields(type).reject { |key, v| (main_custom_fields.values+DEFAULT_REQUIRED_KEYS).include?(v['key'] || key) }
              .map { |k, value| value['name'] }
       end
 


### PR DESCRIPTION
The Jira REST API has a slight difference between
the cloud and server versions. The server version
doesn't have a 'key' value in the entrys in the
'fields' (it is a hash) property of the 'issuetype'
resource. This will check the actual key in the 'fields'
hash in the case that it doesn't have a value called 'key'

for example, the cloud api returns
```json

"customfield_10003: {
  "name": "Epic Name",
  "key": "customfield_10003",
  ...
 }
```

while the server api returns

```json
"customfield_10003": {
  "name": "Epic Name",
  ...
}
```

This change will utilize the previous behavior, but if it is not found it will go off of the hash's actual key and not the hash's value that has the key "key"